### PR TITLE
feat: add -chromePath flag to specify Chrome executable path

### DIFF
--- a/config.go
+++ b/config.go
@@ -14,6 +14,8 @@ type Config struct {
 	SaveDirectory string `json:"save_directory"`
 	// Cookies文件路径
 	CookiesFile string `json:"cookies_file"`
+	// Chrome可执行文件路径
+	ChromePath string `json:"chrome_path"`
 	// Chrome超时时间（分钟）
 	ChromeTimeout int `json:"chrome_timeout"`
 	// HTTP超时时间（秒）
@@ -49,6 +51,7 @@ func DefaultConfig() *Config {
 		ThreadCount:   10,
 		SaveDirectory: "video/",
 		CookiesFile:   filepath.Join(configDir, "cookies.json"),
+		ChromePath:    "",
 		ChromeTimeout: 20,
 		HTTPTimeout:   30,
 	}

--- a/main.go
+++ b/main.go
@@ -201,6 +201,18 @@ func startChrome(config *Config) error {
 		chromedp.NoDefaultBrowserCheck,
 	)
 
+	// 如果指定了 Chrome 路径，使用它
+	if config.ChromePath != "" {
+		normalizedPath := normalizePathForRuntime(config.ChromePath)
+		if normalizedPath != config.ChromePath {
+			fmt.Printf("Chrome路径已转换: %s → %s\n", config.ChromePath, normalizedPath)
+		}
+		opts = append(opts, chromedp.ExecPath(normalizedPath))
+		fmt.Printf("使用指定的Chrome路径: %s\n", normalizedPath)
+	} else {
+		fmt.Println("使用系统自动查找的Chrome")
+	}
+
 	var siteCookies []*network.Cookie
 	parentCtx, cancel := chromedp.NewExecAllocator(context.Background(), opts...)
 	defer cancel()
@@ -642,6 +654,7 @@ func main() {
 	videoListFile := flag.String("videoList", "", "视频列表文件路径，格式为 -videoList \"/path/to/video_list.txt\"")
 	httpTimeout := flag.Int("httpTimeout", 0, "HTTP超时时间，单位秒 (默认: 30)")
 	chromeTimeout := flag.Int("chromeTimeout", 0, "Chrome登录超时时间，单位分钟 (默认: 20)")
+	chromePath := flag.String("chromePath", "", "Chrome可执行文件路径，用于指定特定的Chrome/Chromium位置")
 	cookiesFile := flag.String("cookies", "", "Cookies文件路径")
 
 	flag.Parse()
@@ -671,6 +684,9 @@ func main() {
 	}
 	if *chromeTimeout > 0 {
 		config.ChromeTimeout = *chromeTimeout
+	}
+	if *chromePath != "" {
+		config.ChromePath = *chromePath
 	}
 	if *cookiesFile != "" {
 		config.CookiesFile = *cookiesFile


### PR DESCRIPTION
## 功能描述

添加 -chromePath 参数，允许用户指定 Chrome/Chromium 可执行文件的路径，解决 Chrome 无法自动找到的问题。

## 使用方式

```bash
# 指定 Chrome 路径（Windows）
./GoDingtalk -login -chromePath "C:\Program Files\Google\Chrome\Application\chrome.exe"

# 指定 Chromium 路径（Linux）
./GoDingtalk -login -chromePath "/usr/bin/chromium-browser"

# 指定 Chrome 路径（macOS）
./GoDingtalk -login -chromePath "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
```

## 关联 Issue

Fixes #7